### PR TITLE
Add 1.11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>org.inventivetalent</groupId>
     <artifactId>reflectionhelper</artifactId>
-    <version>1.10.5-SNAPSHOT</version>
+    <version>1.11.0-SNAPSHOT</version>
 
     <build>
         <finalName>ReflectionHelper_v${project.version}</finalName>

--- a/src/main/java/org/inventivetalent/reflection/minecraft/Minecraft.java
+++ b/src/main/java/org/inventivetalent/reflection/minecraft/Minecraft.java
@@ -126,7 +126,9 @@ public class Minecraft {
 		v1_9_R1(10901),
 		v1_9_R2(10902),
 
-		v1_10_R1(11001);
+		v1_10_R1(11001),
+
+		v1_11_R1(11101);
 
 		private int version;
 


### PR DESCRIPTION
This contains initial 1.11 support by adding 1.11 to the version enum. This change (and only this change) made BossBarAPI work. I'm sure that other changes are probably required with other plugins.