### PR TITLE
Enhance NMS Class Resolver 

### DIFF
--- a/src/main/java/org/inventivetalent/reflection/minecraft/Minecraft.java
+++ b/src/main/java/org/inventivetalent/reflection/minecraft/Minecraft.java
@@ -145,7 +145,7 @@ public class Minecraft {
         v1_16_R2(11602),
         v1_16_R3(11603),
 
-        v1_17_R1(11701, "net.minecraft", "org.bukkit.craftbukkit.%s"),
+        v1_17_R1(11701, "net.minecraft", "org.bukkit.craftbukkit.%s", false),
 
         /// (Potentially) Upcoming versions
         v1_18_R1(11801),
@@ -154,8 +154,8 @@ public class Minecraft {
 
         private final MinecraftVersion version;
 
-        Version(int version, String nmsFormat, String obcFormat) {
-            this.version = new MinecraftVersion(name(), version, nmsFormat, obcFormat);
+        Version(int version, String nmsFormat, String obcFormat, boolean nmsVersionPrefix) {
+            this.version = new MinecraftVersion(name(), version, nmsFormat, obcFormat, nmsVersionPrefix);
         }
 
         Version(int version) {

--- a/src/main/java/org/inventivetalent/reflection/minecraft/MinecraftVersion.java
+++ b/src/main/java/org/inventivetalent/reflection/minecraft/MinecraftVersion.java
@@ -24,19 +24,20 @@ public class MinecraftVersion {
     private final String obcFormat;
     private final String nmsPackage;
     private final String obcPackage;
+    private final boolean nmsVersionPrefix;
 
-
-    MinecraftVersion(String packageName, int version, String nmsFormat, String obcFormat) {
+    MinecraftVersion(String packageName, int version, String nmsFormat, String obcFormat, boolean nmsVersionPrefix) {
         this.packageName = packageName;
         this.version = version;
         this.nmsFormat = nmsFormat;
         this.obcFormat = obcFormat;
         this.nmsPackage = String.format(this.nmsFormat, packageName);
         this.obcPackage = String.format(this.obcFormat, packageName);
+        this.nmsVersionPrefix = nmsVersionPrefix;
     }
 
     MinecraftVersion(String packageName, int version) {
-        this(packageName, version, "net.minecraft.server.%s", "org.bukkit.craftbukkit.%s");
+        this(packageName, version, "net.minecraft.server.%s", "org.bukkit.craftbukkit.%s", true);
     }
 
     // Used by SantiyCheck
@@ -71,6 +72,13 @@ public class MinecraftVersion {
      */
     public String getObcPackage() {
         return obcPackage;
+    }
+
+    /**
+     * @return if the nms package name has version prefix
+     */
+    public boolean hasNMSVersionPrefix() {
+        return nmsVersionPrefix;
     }
 
     /**

--- a/src/main/java/org/inventivetalent/reflection/resolver/minecraft/NMSClassResolver.java
+++ b/src/main/java/org/inventivetalent/reflection/resolver/minecraft/NMSClassResolver.java
@@ -1,6 +1,7 @@
 package org.inventivetalent.reflection.resolver.minecraft;
 
 import org.inventivetalent.reflection.minecraft.Minecraft;
+import org.inventivetalent.reflection.minecraft.MinecraftVersion;
 import org.inventivetalent.reflection.resolver.ClassResolver;
 
 /**
@@ -13,6 +14,16 @@ public class NMSClassResolver extends ClassResolver {
 		for (int i = 0; i < names.length; i++) {
 			if (!names[i].startsWith("net.minecraft")) {
 				names[i] = Minecraft.getNMSPackage() + "." + names[i];
+			} else if (names[i].contains(".")) {
+				/* name contains dot but don't start with NMS (ex: world.entity.Entity) */
+				if (MinecraftVersion.VERSION.hasNMSVersionPrefix()) {
+					/* use class name only */
+					String[] path = names[i].split("\\.");
+					names[i] = Minecraft.getNMSPackage() + "." + path[path.length - 1];
+				} else {
+					/* use the whole name */
+					names[i] = Minecraft.getNMSPackage() + "." + names[i];
+				}
 			}
 		}
 		return super.resolve(names);


### PR DESCRIPTION
Enhance the resolver to resolve NMS classes for 1.17+ with less queries.

I was checking the NMS errors in GlowAPI and thought this enhancement will help solve most of these errors.

## Example
```java
Class<?> entity$class = NMSClassResolver.resolve("world.entity.Entity");
```

## How it works
If the NMS version includes version prefix like (`net.minecraft.server.v1_16_R3`)
then, it will look for `Class.forName("net.minecraft.server.v1_16_R3.Entity")`.
Basically grabbing the last word in the query which is the class name.

If the NMS version doesn't include version perfix like in `v1_17_R1`
then, it will look for `Class.forName("net.minecraft.world.entity.Entity")`.